### PR TITLE
readme: use weaker emphasis in license section

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ NixOS weekly content is licensed under the [Creative Commons
 Attribution-ShareAlike 4.0 International Public License][cc-by-sa-4.0].
 
 In short this means that you can share and adapt the material for any purpose
-as long as you **give appropriate credit**, **indicate if any changes were
-made** and redistribute your modifications under the **same license**. For full
-details, see [COPYING](/COPYING).
+as long as you *give appropriate credit*, *indicate if any changes were made*
+and redistribute your modifications under the *same license*. For full details,
+see [COPYING](/COPYING).
 
 [cc-by-sa-4.0]: https://creativecommons.org/licenses/by-sa/4.0/


### PR DESCRIPTION
Actually looking at it now, I feel like the strong emphasis looks out of place, and that italics is probably more appropriate? Of course this is completely subjective, so feel free to reject!
