### PR TITLE
Create github-issue-stats for generating issue open /close information

### DIFF
--- a/tools/github-issue-stats/default.nix
+++ b/tools/github-issue-stats/default.nix
@@ -1,0 +1,23 @@
+{ pkgs ? import <nixpkgs> {} }:
+let
+
+  inherit (pkgs.python3Packages) buildPythonPackage;
+
+in buildPythonPackage {
+  name = "github-issue-stats";
+  src = ./src;
+
+  preBuild = ''
+    flake8 $src
+  '';
+
+  buildInputs = with pkgs.python3Packages; [
+    flake8
+  ];
+
+  propagatedBuildInputs = with pkgs.python3Packages; [
+    requests2
+    dateutil
+  ];
+
+}

--- a/tools/github-issue-stats/src/github_issue_stats/main.py
+++ b/tools/github-issue-stats/src/github_issue_stats/main.py
@@ -1,0 +1,98 @@
+import argparse
+import os
+from pprint import pprint  # noqa
+import logging
+import dateutil.parser
+from datetime import timedelta
+import json
+from . import github_issue_source
+
+logging.basicConfig(level=logging.DEBUG)
+
+
+def build_report(issue_source, owner_repo, report_begin, report_end):
+    def in_range(date):
+        date = dateutil.parser.parse(date)
+        if report_begin < date and date < report_end:
+            return True
+        return False
+
+    stats = {
+        "new_issues": 0,
+        "closed_issues": 0,
+        "new_prs": 0,
+        "closed_prs": 0
+    }
+
+    for issue in issue_source.issues_for(owner_repo, report_begin):
+        is_pr = 'pull_request' in issue
+        if issue['closed_at'] is not None:
+            if in_range(issue['closed_at']):
+                if is_pr:
+                    stats['closed_prs'] += 1
+                else:
+                    stats['closed_issues'] += 1
+
+        if in_range(issue['created_at']):
+            if is_pr:
+                stats['new_prs'] += 1
+            else:
+                stats['new_issues'] += 1
+
+    return stats
+
+
+def main():
+    '''
+    Magic Environment Variables:
+
+     - GITHUB_API: https://api.github.com for changing to GH Enterprise
+     - BE_A_BAD_GITHUB_CITIZEN: set to 1 to disable rate limiting. Instead
+       of disabling rate limiting, you should authenticate to GitHub.
+       Check out the .netrc example below.
+     - REPORT_DURATION: How many days should the report be for? default: 7
+
+    Notes:
+     - report_date is forced to be at 00:00:00 in UTC on the used date
+
+    Authenticating to GitHub? Create a file at ~/.netrc with:
+
+        machine api.github.com
+        login youruser
+        password <api-key>
+    '''
+
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description='Create a Github issue report',
+        epilog=main.__doc__
+    )
+
+    parser.add_argument('project', type=str,
+                        help='Example: NixOS/nixpkgs')
+    parser.add_argument('report_date', type=str,
+                        help='Date to run report for, ex: 2016-08-01')
+
+    args = parser.parse_args()
+
+    owner_repo = args.project
+    report_end = dateutil.parser.parse(
+        '{}T00:00:00Z'.format(args.report_date)
+    )
+
+    api_endpoint = os.environ.get('GITHUB_API', 'https://api.github.com')
+    ignore_ratelimit = int(os.environ.get('BE_A_BAD_GITHUB_CITIZEN', 0)) != 0
+    report_duration = int(os.environ.get('REPORT_DURATION', 7))
+
+    report_begin = report_end - timedelta(days=report_duration)
+
+    gh_client = github_issue_source.GithubIssueSource(
+        base_url=api_endpoint,
+        ignore_ratelimit=ignore_ratelimit
+    )
+
+    print(json.dumps(
+        build_report(gh_client, owner_repo, report_begin, report_end),
+        indent=4,
+        sort_keys=True
+    ))

--- a/tools/github-issue-stats/src/setup.py
+++ b/tools/github-issue-stats/src/setup.py
@@ -1,0 +1,26 @@
+from setuptools import setup
+
+setup(
+    name="github-issue-stats",
+    version="0.0.1",
+    author="Graham Christensen",
+    author_email="graham@grahamc.com",
+    description=("Collect and report weekly stats of NixOS issues"),
+    license="MIT",
+    keywords="github issue statistics nixos",
+    url="https://github.com/NixOS/nixos-weekly/",
+    packages=['github_issue_stats'],
+    entry_points={
+        'console_scripts': [
+            'github-issue-stats = github_issue_stats.main:main'
+        ],
+    },
+    install_requires=[
+        # Commented out because it wasn't working with buildPythonPackage
+        # See default.nix for a more up to date version.
+        #        'requests>2.11.0',
+        #        'dateutil'
+    ],
+    test_suite="github_issue_stats"
+
+)

--- a/tools/github-issue-stats/test
+++ b/tools/github-issue-stats/test
@@ -1,0 +1,6 @@
+{
+    "closed_issues": 47,
+    "closed_prs": 178,
+    "new_issues": 54,
+    "new_prs": 173
+}


### PR DESCRIPTION
Output to standard out looks like this:

```
{
    "closed_issues": 47,
    "closed_prs": 178,
    "new_issues": 54,
    "new_prs": 173
}
```

Note it emits extra stuff to stderr while running.

Help Output:

```
 ./result/bin/github-issue-stats -h
usage: github-issue-stats [-h] project report_date

Create a Github issue report

positional arguments:
  project      Example: NixOS/nixpkgs
  report_date  Date to run report for, ex: 2016-08-01

optional arguments:
  -h, --help   show this help message and exit

    Magic Environment Variables:

     - GITHUB_API: https://api.github.com for changing to GH Enterprise
     - BE_A_BAD_GITHUB_CITIZEN: set to 1 to disable rate limiting. Instead
       of disabling rate limiting, you should authenticate to GitHub.
       Check out the .netrc example below.
     - REPORT_DURATION: How many days should the report be for? default: 7

    Notes:
     - report_date is forced to be at 00:00:00 in UTC on the used date

    Authenticating to GitHub? Create a file at ~/.netrc with:

        machine api.github.com
        login youruser
        password <api-key>

```

This note about netrc is important. This script implements ratelimiting to be a good citizen, and without the .netrc it'll be very slow. You can disable ratelimiting but several times I've run out of requests in the middle of making a report.

Example Output:

```
$ ./result/bin/github-issue-stats nixos/nixpkgs 2016-09-04 > test
INFO:requests.packages.urllib3.connectionpool:Starting new HTTPS connection (1): api.github.com
DEBUG:requests.packages.urllib3.connectionpool:"GET /repos/nixos/nixpkgs/issues?state=all&since=2016-08-28T00%3A00%3A00%2B00%3A00Z HTTP/1.1" 200 None
DEBUG:root:Rate limit delay 0s (4982/5000 resets at 1472992420)
DEBUG:requests.packages.urllib3.connectionpool:"GET /repositories/4542716/issues?state=all&since=2016-08-28T00%3A00%3A00%2B00%3A00Z&page=2 HTTP/1.1" 200 None
DEBUG:root:Rate limit delay 0s (4981/5000 resets at 1472992420)
DEBUG:requests.packages.urllib3.connectionpool:"GET /repositories/4542716/issues?state=all&since=2016-08-28T00%3A00%3A00%2B00%3A00Z&page=3 HTTP/1.1" 200 None
DEBUG:root:Rate limit delay 0s (4980/5000 resets at 1472992420)
DEBUG:requests.packages.urllib3.connectionpool:"GET /repositories/4542716/issues?state=all&since=2016-08-28T00%3A00%3A00%2B00%3A00Z&page=4 HTTP/1.1" 200 None
DEBUG:root:Rate limit delay 0s (4979/5000 resets at 1472992420)
DEBUG:requests.packages.urllib3.connectionpool:"GET /repositories/4542716/issues?state=all&since=2016-08-28T00%3A00%3A00%2B00%3A00Z&page=5 HTTP/1.1" 200 None
DEBUG:root:Rate limit delay 0s (4978/5000 resets at 1472992420)
DEBUG:requests.packages.urllib3.connectionpool:"GET /repositories/4542716/issues?state=all&since=2016-08-28T00%3A00%3A00%2B00%3A00Z&page=6 HTTP/1.1" 200 None
DEBUG:root:Rate limit delay 0s (4977/5000 resets at 1472992420)
DEBUG:requests.packages.urllib3.connectionpool:"GET /repositories/4542716/issues?state=all&since=2016-08-28T00%3A00%3A00%2B00%3A00Z&page=7 HTTP/1.1" 200 None
DEBUG:root:Rate limit delay 0s (4976/5000 resets at 1472992420)
DEBUG:requests.packages.urllib3.connectionpool:"GET /repositories/4542716/issues?state=all&since=2016-08-28T00%3A00%3A00%2B00%3A00Z&page=8 HTTP/1.1" 200 None
DEBUG:root:Rate limit delay 0s (4975/5000 resets at 1472992420)
DEBUG:requests.packages.urllib3.connectionpool:"GET /repositories/4542716/issues?state=all&since=2016-08-28T00%3A00%3A00%2B00%3A00Z&page=9 HTTP/1.1" 200 None
DEBUG:root:Rate limit delay 0s (4974/5000 resets at 1472992420)
DEBUG:requests.packages.urllib3.connectionpool:"GET /repositories/4542716/issues?state=all&since=2016-08-28T00%3A00%3A00%2B00%3A00Z&page=10 HTTP/1.1" 200 None
DEBUG:root:Rate limit delay 0s (4973/5000 resets at 1472992420)
DEBUG:requests.packages.urllib3.connectionpool:"GET /repositories/4542716/issues?state=all&since=2016-08-28T00%3A00%3A00%2B00%3A00Z&page=11 HTTP/1.1" 200 None
DEBUG:root:Rate limit delay 0s (4972/5000 resets at 1472992420)
DEBUG:requests.packages.urllib3.connectionpool:"GET /repositories/4542716/issues?state=all&since=2016-08-28T00%3A00%3A00%2B00%3A00Z&page=12 HTTP/1.1" 200 None
DEBUG:root:Rate limit delay 0s (4971/5000 resets at 1472992420)
DEBUG:requests.packages.urllib3.connectionpool:"GET /repositories/4542716/issues?state=all&since=2016-08-28T00%3A00%3A00%2B00%3A00Z&page=13 HTTP/1.1" 200 None
DEBUG:root:Rate limit delay 0s (4970/5000 resets at 1472992420)
DEBUG:requests.packages.urllib3.connectionpool:"GET /repositories/4542716/issues?state=all&since=2016-08-28T00%3A00%3A00%2B00%3A00Z&page=14 HTTP/1.1" 200 None
DEBUG:root:Rate limit delay 0s (4969/5000 resets at 1472992420)
DEBUG:requests.packages.urllib3.connectionpool:"GET /repositories/4542716/issues?state=all&since=2016-08-28T00%3A00%3A00%2B00%3A00Z&page=15 HTTP/1.1" 200 None
$ cat test
{
    "closed_issues": 47,
    "closed_prs": 178,
    "new_issues": 54,
    "new_prs": 173
}
```
