### PR TITLE
Make site generation more generic

### DIFF
--- a/templates/atom.nix
+++ b/templates/atom.nix
@@ -1,6 +1,6 @@
 { conf, state, lib, templates,  ... }:
 with lib;
-posts:
+page:
   ''
     <feed xmlns="http://www.w3.org/2005/Atom"
           xmlns:planet="http://namespace.uri/"
@@ -20,7 +20,7 @@ posts:
       <link href="${conf.siteUrl}/atom.xml" rel="self" type="application/atom+xml"/>
       <link href="${conf.siteUrl}" rel="alternate"/>
       
-      ${concatMapStringsSep "\n" templates.post.atomList posts}
+      ${concatMapStringsSep "\n" templates.post.atomList page.posts}
 
     </feed>
   ''


### PR DESCRIPTION
Successor of #22, this is a set of changes to make the generation more generic.

This include:
- page attribute sets are now consitent; so pages, posts and feed can be generated in the same way
- added `preInstall` and `postInstall` hooks to `generateSite`

Note: I will continue this effort in https://github.com/ericsagnes/styx so will not much submit PRs here from now.
