### PR TITLE
Fix typo in title

### DIFF
--- a/content/2018/10-arch64-builders-nixops-alternative-optimized-docker-layers-hercules-ci.rst
+++ b/content/2018/10-arch64-builders-nixops-alternative-optimized-docker-layers-hercules-ci.rst
@@ -1,5 +1,5 @@
-#10 - Arch64 builders, NixOps alternative, optimised docker layers, Hercules CI
-###############################################################################
+#10 - AArch64 builders, NixOps alternative, optimised docker layers, Hercules CI
+################################################################################
 
 :date: 2018-10-03
 :description: Start by doing what's necessary; then do what's possible; and suddenly you are doing the impossible.


### PR DESCRIPTION
AArch64 refers to the 64-bit ARM instruction set