### PR TITLE
Rename mailing list link to discourse

### DIFF
--- a/theme/templates/base.html
+++ b/theme/templates/base.html
@@ -115,7 +115,7 @@
               <a href="https://twitter.com/nixos_org" target="_blank">Twitter</a>
           </li>
           <li>
-              <a href="https://discourse.nixos.org" target="_blank">Mailing list</a>
+              <a href="https://discourse.nixos.org" target="_blank">Discourse</a>
           </li>
       </ul>
   </footer>


### PR DESCRIPTION
The link was fixed to point to discourse but it wasn't renamed as well, this PR should fix that.